### PR TITLE
Asynchronous snapshots

### DIFF
--- a/src/EventSourcing/SnapshottingEventSourcingRepository.php
+++ b/src/EventSourcing/SnapshottingEventSourcingRepository.php
@@ -15,9 +15,8 @@ use Broadway\Domain\AggregateRoot;
 use Broadway\EventSourcing\EventSourcingRepository;
 use Broadway\EventStore\EventStore;
 use Broadway\Repository\Repository;
-use Broadway\Snapshotting\Snapshot\Snapshot;
-use Broadway\Snapshotting\Snapshot\SnapshotNotFoundException;
 use Broadway\Snapshotting\Snapshot\SnapshotRepository;
+use Broadway\Snapshotting\Snapshot\Snapshotter;
 use Broadway\Snapshotting\Snapshot\Trigger;
 
 class SnapshottingEventSourcingRepository implements Repository
@@ -26,17 +25,20 @@ class SnapshottingEventSourcingRepository implements Repository
     private $eventStore;
     private $snapshotRepository;
     private $trigger;
+    private $snapshotter;
 
     public function __construct(
         EventSourcingRepository $eventSourcingRepository,
         EventStore $eventStore,
         SnapshotRepository $snapshotRepository,
-        Trigger $trigger
+        Trigger $trigger,
+        Snapshotter $snapshotter
     ) {
         $this->eventSourcingRepository = $eventSourcingRepository;
         $this->eventStore              = $eventStore;
         $this->snapshotRepository      = $snapshotRepository;
         $this->trigger                 = $trigger;
+        $this->snapshotter             = $snapshotter;
     }
 
     /**
@@ -67,9 +69,7 @@ class SnapshottingEventSourcingRepository implements Repository
         $this->eventSourcingRepository->save($aggregate);
 
         if ($takeSnaphot) {
-            $this->snapshotRepository->save(
-                new Snapshot($aggregate)
-            );
+            $this->snapshotter->takeSnapshot($aggregate);
         }
     }
 }

--- a/src/Snapshot/Command/ScheduleSnapshot.php
+++ b/src/Snapshot/Command/ScheduleSnapshot.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot\Command;
+
+final class ScheduleSnapshot
+{
+    /**
+     * @var string
+     */
+    private $aggregateRootId;
+
+    /**
+     * @var string
+     */
+    private $aggregateClass;
+
+    /**
+     * @param string $aggregateRootId
+     * @param string $aggregateClass
+     */
+    public function __construct($aggregateRootId, $aggregateClass)
+    {
+        $this->aggregateRootId = $aggregateRootId;
+        $this->aggregateClass = $aggregateClass;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAggregateRootId()
+    {
+        return $this->aggregateRootId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAggregateClass()
+    {
+        return $this->aggregateClass;
+    }
+}

--- a/src/Snapshot/InMemorySnapshotRepository.php
+++ b/src/Snapshot/InMemorySnapshotRepository.php
@@ -24,7 +24,7 @@ class InMemorySnapshotRepository implements SnapshotRepository
      */
     public function load($id)
     {
-        return isset($this->store[$id]) ? $this->store[$id] : null;
+        return isset($this->store[$id]) ? unserialize($this->store[$id]) : null;
     }
 
     /**
@@ -32,8 +32,7 @@ class InMemorySnapshotRepository implements SnapshotRepository
      */
     public function save(Snapshot $snapshot)
     {
-        // Clone to prevent unintentional mutation.
         return $this->store[$snapshot->getAggregateRoot()->getAggregateRootId()] =
-            new Snapshot(clone $snapshot->getAggregateRoot());
+            serialize($snapshot);
     }
 }

--- a/src/Snapshot/InMemorySnapshotRepository.php
+++ b/src/Snapshot/InMemorySnapshotRepository.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot;
+
+class InMemorySnapshotRepository implements SnapshotRepository
+{
+    /**
+     * @var Snapshot[]
+     */
+    private $store = [];
+
+    /**
+     * @param mixed $id should be unique across aggregate types
+     *
+     * @return Snapshot|null
+     */
+    public function load($id)
+    {
+        return isset($this->store[$id]) ? $this->store[$id] : null;
+    }
+
+    /**
+     * @param Snapshot $snapshot
+     */
+    public function save(Snapshot $snapshot)
+    {
+        // Clone to prevent unintentional mutation.
+        return $this->store[$snapshot->getAggregateRoot()->getAggregateRootId()] =
+            new Snapshot(clone $snapshot->getAggregateRoot());
+    }
+}

--- a/src/Snapshot/Snapshotter.php
+++ b/src/Snapshot/Snapshotter.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot;
+
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+
+interface Snapshotter
+{
+    /**
+     * @param EventSourcedAggregateRoot $aggregateRoot
+     */
+    public function takeSnapshot(EventSourcedAggregateRoot $aggregateRoot);
+}

--- a/src/Snapshot/Snapshotter/CommandDispatchingSnapshotter.php
+++ b/src/Snapshot/Snapshotter/CommandDispatchingSnapshotter.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot\Snapshotter;
+
+use Broadway\CommandHandling\CommandBus;
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+use Broadway\Snapshotting\Snapshot\Command\ScheduleSnapshot;
+use Broadway\Snapshotting\Snapshot\Snapshotter;
+
+class CommandDispatchingSnapshotter implements Snapshotter
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @param CommandBus $commandBus
+     */
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * @param EventSourcedAggregateRoot $aggregateRoot
+     */
+    public function takeSnapshot(EventSourcedAggregateRoot $aggregateRoot)
+    {
+        $this->commandBus->dispatch(
+            new ScheduleSnapshot(
+                $aggregateRoot->getAggregateRootId(),
+                get_class($aggregateRoot)
+            )
+        );
+    }
+}

--- a/src/Snapshot/Snapshotter/SynchronousSnapshotter.php
+++ b/src/Snapshot/Snapshotter/SynchronousSnapshotter.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot\Snapshotter;
+
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+use Broadway\Snapshotting\Snapshot\Snapshot;
+use Broadway\Snapshotting\Snapshot\SnapshotRepository;
+use Broadway\Snapshotting\Snapshot\Snapshotter;
+
+class SynchronousSnapshotter implements Snapshotter
+{
+    /**
+     * @var SnapshotRepository
+     */
+    private $snapshotRepository;
+
+    /**
+     * @param SnapshotRepository $snapshotRepository
+     */
+    public function __construct(SnapshotRepository $snapshotRepository)
+    {
+        $this->snapshotRepository = $snapshotRepository;
+    }
+
+    /**
+     * @param EventSourcedAggregateRoot $aggregateRoot
+     */
+    public function takeSnapshot(EventSourcedAggregateRoot $aggregateRoot)
+    {
+        $this->snapshotRepository->save(new Snapshot($aggregateRoot));
+    }
+}

--- a/test/Snapshot/InMemorySnapshotRepositoryTest.php
+++ b/test/Snapshot/InMemorySnapshotRepositoryTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot;
+
+class InMemorySnapshotRepositoryTest extends SnapshotRepositoryTest
+{
+    /**
+     * @return SnapshotRepository
+     */
+    protected function createRepository()
+    {
+        return new InMemorySnapshotRepository();
+    }
+}

--- a/test/Snapshot/SnapshotRepositoryTest.php
+++ b/test/Snapshot/SnapshotRepositoryTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot;
+
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+
+abstract class SnapshotRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SnapshotRepository
+     */
+    protected $repository;
+
+    /**
+     * @test
+     */
+    public function it_implements_SnapshotRepository()
+    {
+        $this->assertInstanceOf(SnapshotRepository::class, $this->repository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_when_no_snapshot_available()
+    {
+        $this->assertNull($this->repository->load(42));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_snapshot_when_available()
+    {
+        $aggregate = $this->createAggregateWithHistory(5);
+        $this->repository->save(new Snapshot($aggregate));
+
+        // Applying another event to Snapshotted Aggregate should not affect Snapshot version
+        $aggregate->apply(new MyEvent());
+        $aggregate->getUncommittedEvents();
+
+        $this->assertEquals(
+            new Snapshot($this->createAggregateWithHistory(5)),
+            $this->repository->load(42)
+        );
+    }
+
+    /**
+     * @return SnapshotRepository
+     */
+    protected abstract function createRepository();
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->repository = $this->createRepository();
+    }
+
+    /**
+     * @param int $numberOfEvents
+     */
+    private function createAggregateWithHistory($numberOfEvents)
+    {
+        $aggregate = new MyAggregate();
+        for ($i = 0; $i < $numberOfEvents; $i++) {
+            $aggregate->apply(new MyEvent());
+        }
+        $aggregate->getUncommittedEvents(); // Flush events
+        return $aggregate;
+    }
+}
+
+final class MyAggregate extends EventSourcedAggregateRoot
+{
+    private $foo = 0;
+
+    /**
+     * @return string
+     */
+    public function getAggregateRootId()
+    {
+        return 42;
+    }
+
+    protected function applyMyEvent()
+    {
+        $this->foo += 5;
+    }
+}
+
+final class MyEvent
+{
+}

--- a/test/Snapshot/SnapshotRepositoryTest.php
+++ b/test/Snapshot/SnapshotRepositoryTest.php
@@ -43,9 +43,40 @@ abstract class SnapshotRepositoryTest extends \PHPUnit_Framework_TestCase
         $aggregate = $this->createAggregateWithHistory(5);
         $this->repository->save(new Snapshot($aggregate));
 
+        $this->assertEquals(
+            new Snapshot($aggregate),
+            $this->repository->load(42)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_mutate_state_of_Snapshot_Aggregate_after_persisting()
+    {
+        $aggregate = $this->createAggregateWithHistory(5);
+        $this->repository->save(new Snapshot($aggregate));
+
         // Applying another event to Snapshotted Aggregate should not affect Snapshot version
         $aggregate->apply(new MyEvent());
         $aggregate->getUncommittedEvents();
+
+        $snapshot = $this->repository->load(42);
+        $this->assertEquals(new Snapshot($this->createAggregateWithHistory(5)), $snapshot);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_mutate_state_of_Snapshot_Aggregate_after_loading()
+    {
+        $aggregate = $this->createAggregateWithHistory(5);
+        $this->repository->save(new Snapshot($aggregate));
+
+        $snapshot = $this->repository->load(42);
+        $loadedAggregate = $snapshot->getAggregateRoot();
+        $loadedAggregate->apply(new MyEvent());
+        $loadedAggregate->getUncommittedEvents();
 
         $this->assertEquals(
             new Snapshot($this->createAggregateWithHistory(5)),

--- a/test/Snapshot/Snapshotter/CommandDispatchingSnapshotterTest.php
+++ b/test/Snapshot/Snapshotter/CommandDispatchingSnapshotterTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot\Snapshotter;
+
+use Broadway\CommandHandling\CommandBus;
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+use Broadway\Snapshotting\Snapshot\Command\ScheduleSnapshot;
+
+class CommandDispatchingSnapshotterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var CommandDispatchingSnapshotter
+     */
+    private $snapshotter;
+
+    /**
+     * @test
+     */
+    public function it_dispatches_ScheduleSnapshot_command()
+    {
+        $this->commandBus
+            ->dispatch(
+                new ScheduleSnapshot(
+                    42,
+                    'Broadway\Snapshotting\Snapshot\Snapshotter\MyOtherAggregate'
+                )
+            )
+            ->shouldBeCalled();
+
+        $this->snapshotter->takeSnapshot(new MyOtherAggregate());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->commandBus = $this->prophesize(CommandBus::class);
+        $this->snapshotter = new CommandDispatchingSnapshotter($this->commandBus->reveal());
+    }
+}
+
+final class MyOtherAggregate extends EventSourcedAggregateRoot
+{
+    /**
+     * @return string
+     */
+    public function getAggregateRootId()
+    {
+        return 42;
+    }
+}

--- a/test/Snapshot/Snapshotter/SynchronousSnapshotterTest.php
+++ b/test/Snapshot/Snapshotter/SynchronousSnapshotterTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the broadway/snapshotting package.
+ *
+ *  (c) Qandidate.com <opensource@qandidate.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Broadway\Snapshotting\Snapshot\Snapshotter;
+
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+use Broadway\Snapshotting\Snapshot\Snapshot;
+use Broadway\Snapshotting\Snapshot\SnapshotRepository;
+
+class SynchronousSnapshotterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SnapshotRepository
+     */
+    private $repository;
+
+    /**
+     * @var SynchronousSnapshotter
+     */
+    private $snapshotter;
+
+    /**
+     * @test
+     */
+    public function it_persists_directly_to_SnapshotRepository()
+    {
+        $aggregate = new MyAggregate();
+
+        $this->repository
+            ->save(new Snapshot($aggregate))
+            ->shouldBeCalled();
+
+        $this->snapshotter->takeSnapshot($aggregate);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->repository = $this->prophesize(SnapshotRepository::class);
+        $this->snapshotter = new SynchronousSnapshotter($this->repository->reveal());
+    }
+}
+
+final class MyAggregate extends EventSourcedAggregateRoot
+{
+    /**
+     * @return string
+     */
+    public function getAggregateRootId()
+    {
+        return 42;
+    }
+}


### PR DESCRIPTION
This introduces an in memory implementation of the `SnapshotRepository` and a new `Snapshotter` interface which is responsible for taking (or scheduling) Snapshots.

The Snapshotter is split into 2 different versions

- the `SynchronousSnapshotter`, which persists the Snapshot directly into the SnapshotRepository, and
- the `CommandDispatchingSnapshotter`, which dispatches a `ScheduleSnapshot` command on a CommandBus, which should allow for asynchronous processing