### PR TITLE
The typing satisfying the Repository interface has been added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.idea

--- a/src/EventSourcing/SnapshottingEventSourcingRepository.php
+++ b/src/EventSourcing/SnapshottingEventSourcingRepository.php
@@ -60,7 +60,7 @@ class SnapshottingEventSourcingRepository implements Repository
     /**
      * {@inheritdoc}
      */
-    public function save(AggregateRoot $aggregate)
+    public function save(AggregateRoot $aggregate): void
     {
         $takeSnaphot = $this->trigger->shouldSnapshot($aggregate);
 


### PR DESCRIPTION
@@ -60,7 +60,7 @@ class SnapshottingEventSourcingRepository implements Repository
    /**
     * {@inheritdoc}
     */
-    public function save(AggregateRoot $aggregate)
+    public function save(AggregateRoot $aggregate): void
    {
        $takeSnaphot = $this->trigger->shouldSnapshot($aggregate);